### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Configure API Gateway Throttling Limits

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -122,12 +122,14 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             retention=logs.RetentionDays.ONE_YEAR,
         )
 
-        # Create API Gateway with X-Ray tracing and access logging enabled
+        # Create API Gateway with X-Ray tracing, access logging, and throttling enabled
         apigw_.LambdaRestApi(
             self,
             "Endpoint",
             handler=api_hanlder,
             deploy_options=apigw_.StageOptions(
+                throttling_rate_limit=100,
+                throttling_burst_limit=200,
                 tracing_enabled=True,
                 access_log_destination=apigw_.LogGroupLogDestination(api_log_group),
                 access_log_format=apigw_.AccessLogFormat.json_with_standard_fields(


### PR DESCRIPTION
## Summary

This PR implements API Gateway throttling limits to address AWS Well-Architected Framework REL05-BP02 best practice compliance. The changes configure explicit rate and burst limits at the stage level to protect backend resources from unexpected traffic spikes.

## Changes Made

### API Gateway Throttling Configuration
- Added `throttling_rate_limit=100` (100 requests per second)
- Added `throttling_burst_limit=200` (200 burst capacity)
- Applied throttling at the stage level in `deploy_options`

## Well-Architected Framework Compliance

These changes implement REL05-BP02 "Throttle requests" best practice, mitigating resource exhaustion due to unexpected increases in demand. Without explicit throttling, the API relied on default AWS account-level limits which may not be appropriate for the workload's capacity.

✅ **Prevents Resource Exhaustion**: Throttling limits protect Lambda concurrency and DynamoDB capacity from being overwhelmed
✅ **Enables Graceful Degradation**: Requests exceeding limits receive 429 responses, allowing clients to implement proper retry logic
✅ **Protects Against Traffic Spikes**: Rate and burst limits prevent sudden traffic increases from impacting service availability

## Testing

After deployment:
1. Monitor CloudWatch metric `Count` for API Gateway to track total requests
2. Monitor CloudWatch metric `4XXError` to track throttled requests (429 responses)
3. Load test the API to validate throttling behavior at configured limits
4. Verify clients receive HTTP 429 responses when limits are exceeded

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added throttling configuration to API Gateway stage options

Fixes #5