### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Implement AWS WAF Rate Limiting for API Gateway

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -11,6 +11,7 @@ from aws_cdk import (
     aws_iam as iam,
     aws_logs as logs,
     aws_cloudwatch as cloudwatch,
+    aws_wafv2 as wafv2,
     Duration,
 )
 from constructs import Construct
@@ -144,8 +145,55 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             retention=logs.RetentionDays.ONE_YEAR,
         )
 
+        # Create WAF Web ACL with rate-based rules
+        web_acl = wafv2.CfnWebACL(
+            self,
+            "ApiWebAcl",
+            scope="REGIONAL",
+            default_action=wafv2.CfnWebACL.DefaultActionProperty(allow={}),
+            visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                cloud_watch_metrics_enabled=True,
+                metric_name="ApiWebAclMetrics",
+                sampled_requests_enabled=True
+            ),
+            rules=[
+                wafv2.CfnWebACL.RuleProperty(
+                    name="RateLimitRule",
+                    priority=1,
+                    statement=wafv2.CfnWebACL.StatementProperty(
+                        rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
+                            limit=2000,
+                            aggregate_key_type="IP"
+                        )
+                    ),
+                    action=wafv2.CfnWebACL.RuleActionProperty(block={}),
+                    visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                        cloud_watch_metrics_enabled=True,
+                        metric_name="RateLimitRuleMetrics",
+                        sampled_requests_enabled=True
+                    )
+                ),
+                wafv2.CfnWebACL.RuleProperty(
+                    name="AWSManagedRulesCommonRuleSet",
+                    priority=2,
+                    override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),
+                    statement=wafv2.CfnWebACL.StatementProperty(
+                        managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
+                            vendor_name="AWS",
+                            name="AWSManagedRulesCommonRuleSet"
+                        )
+                    ),
+                    visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                        cloud_watch_metrics_enabled=True,
+                        metric_name="AWSManagedRulesCommonRuleSetMetrics",
+                        sampled_requests_enabled=True
+                    )
+                )
+            ]
+        )
+
         # Create API Gateway with X-Ray tracing, access logging, and throttling enabled
-        apigw_.LambdaRestApi(
+        api = apigw_.LambdaRestApi(
             self,
             "Endpoint",
             handler=api_hanlder,
@@ -166,4 +214,12 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
                     user=True,
                 ),
             ),
+        )
+
+        # Associate WAF with API Gateway stage
+        wafv2.CfnWebACLAssociation(
+            self,
+            "WebAclAssociation",
+            resource_arn=f"arn:aws:apigateway:{self.region}::/restapis/{api.rest_api_id}/stages/{api.deployment_stage.stage_name}",
+            web_acl_arn=web_acl.attr_arn
         )


### PR DESCRIPTION
## Summary

This PR implements AWS WAF with rate-based rules to protect the API Gateway endpoint from DDoS attacks, floods, and malicious traffic. The changes add an additional layer of protection at the network edge before requests reach API Gateway.

## Changes Made

### AWS WAF Web ACL Configuration
- Created WAF Web ACL with REGIONAL scope
- Imported `aws_wafv2` module

### Rate-Based Rule
- Configured rate limit of 2000 requests per 5 minutes per IP address
- Blocks IPs exceeding the rate limit
- Aggregates by IP address using `aggregate_key_type="IP"`

### AWS Managed Rules
- Added AWS Managed Rules Common Rule Set for protection against common threats
- Provides defense against OWASP Top 10 vulnerabilities

### Monitoring and Visibility
- Enabled CloudWatch metrics for Web ACL and all rules
- Enabled sampled requests for security analysis
- Stored API reference to enable WAF association

### WAF Association
- Associated WAF Web ACL with API Gateway stage using resource ARN

## Well-Architected Framework Compliance

These changes implement REL05-BP02 "Throttle requests" best practice by adding IP-based rate limiting at the edge. Without WAF protection, the API was vulnerable to DDoS attacks, retry storms, and individual IPs generating excessive traffic that could exhaust backend resources.

✅ **DDoS Protection**: Rate-based rules block malicious IPs before reaching backend
✅ **Per-IP Rate Limiting**: Prevents single IP from monopolizing resources
✅ **Common Threat Protection**: AWS Managed Rules defend against known attack patterns
✅ **Enhanced Observability**: CloudWatch metrics enable security monitoring and analysis

## Testing

After deployment:
1. Monitor CloudWatch metric `BlockedRequests` for WAF-blocked traffic
2. Review sampled requests in AWS WAF console for blocked IPs
3. Load test from single IP to verify rate limiting at 2000 req per 5 minutes
4. Verify legitimate traffic is not impacted by WAF rules
5. Test common attack patterns to validate AWS Managed Rules

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added WAF Web ACL with rate-based rules and association

Fixes #7